### PR TITLE
Enable to Input meeting_id as URL Param

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -28,6 +28,7 @@ module ZoomGacha
         @gachas = Gacha.all.order(created_at: :desc).includes(:user).limit(20)
         @recent_meetings = Meeting.all.order(updated_at: :desc).limit(10)
         @csrf_token = Rack::Protection::AuthenticityToken.token(env['rack.session'])
+        @meeting_id = params[:meeting_id]
         render 'index'
       else
         render 'login'

--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -5,7 +5,7 @@
     <h2 class="text-gray-100 text-center pb-2">meeting idで回す</h2>
     <form action="/gacha" method="post" class="flex h-8 w-1/2 mx-auto">
       <input type="hidden" name="authenticity_token" value="<%= @csrf_token %>" />
-      <input type="text" name="meeting_id" required class="block w-full mr-2 px-3 py-1.5 text-base font-normal text-gray-700 bg-white bg-clip-padding border border-solid border-gray-300 rounded transition ease-in-out m-0 focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none" placeholder="Meeting ID">
+      <input type="text" name="meeting_id" required class="block w-full mr-2 px-3 py-1.5 text-base font-normal text-gray-700 bg-white bg-clip-padding border border-solid border-gray-300 rounded transition ease-in-out m-0 focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none" placeholder="Meeting ID" value="<%= @meeting_id %>" >
       <input type="submit" value="ガチャを回す" class=" px-6 py-2.5 bg-blue-700 text-white font-medium text-xs leading-tight uppercase rounded shadow-md hover:bg-blue-700 hover:shadow-lg focus:bg-blue-700 focus:shadow-lg focus:outline-none focus:ring-0 active:bg-blue-800 active:shadow-lg transition duration-150 ease-in-out">
     </form>
   </div>


### PR DESCRIPTION
## Motivation

As usage on daily/weekly meetings, we have to input `meeting_id` many times. I'm tired on that.

## What I Do

Enable to input `meeting_id` as URL Param like that: `https://zoom-gacha.example.com?meeting_id=000000000000`.

## What I Don't Do

* no validation
* no testing (I didn't have local env, sorry for my lazyness 🙏)

## etc

It's kind of proposal or feature request, so feel free to close PR if you don't wanna merge my implementation 😌